### PR TITLE
Demote mobile hero heading

### DIFF
--- a/src/En/index.html
+++ b/src/En/index.html
@@ -98,7 +98,7 @@ lang: en
             
             <!-- Content Section -->
             <div class="hero-content-mobile">
-                <h1 class="hero-headline-mobile">Your Health Journey<br>Begins Here</h1>
+                <h2 class="hero-headline-mobile">Your Health Journey<br>Begins Here</h2>
                 <p class="hero-tagline-mobile">Scientific nutrition that works specifically for you</p>
                 
                 <div class="hero-features-mobile">


### PR DESCRIPTION
## Summary
- demote mobile hero headline to H2 so desktop H1 remains primary

## Testing
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bab743e1e483298d8ccfb9985ce527